### PR TITLE
fix(ci): Add PR comment permissions + December translation

### DIFF
--- a/.github/workflows/claude-ci.yml
+++ b/.github/workflows/claude-ci.yml
@@ -16,6 +16,12 @@ on:
     branches:
       - 'claude/**'
 
+# Permisos necesarios para comentar en PRs
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   # Job 1: Análisis y Validación
   analyze:

--- a/lib/generated/l10n/app_localizations_es.dart
+++ b/lib/generated/l10n/app_localizations_es.dart
@@ -215,7 +215,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get novemberShort => 'Nov';
 
   @override
-  String get decemberShort => 'Dec';
+  String get decemberShort => 'Dic';
 
   @override
   String get newHabit => 'Nuevo Ritmo';

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -66,7 +66,7 @@
   "septemberShort": "Sep",
   "octoberShort": "Oct",
   "novemberShort": "Nov",
-  "decemberShort": "Dec",
+  "decemberShort": "Dic",
   "newHabit": "Nuevo Ritmo",
   "save": "Guardar",
   "statsToday": "Hoy",


### PR DESCRIPTION
## Summary
This PR contains **only the unique changes** from PR #2 that were not included in PR #1:

### 1. CI Permissions Fix ✅
- **Problem**: PR comment job was failing with 403 error
- **Solution**: Added `pull-requests: write` and `issues: write` permissions to CI workflow
- **File**: `.github/workflows/claude-ci.yml`

### 2. December Translation Fix ✅  
- **Problem**: Spanish abbreviation for December was `Dec` (English)
- **Solution**: Changed to `Dic` (correct Spanish abbreviation)
- **Files**: `lib/l10n/app_es.arb`, regenerated `lib/generated/l10n/app_localizations_es.dart`

## Why New PR?
PR #2 contained 18 commits with 80+ files (mostly already in master via PR #1 squash merge). This PR is a **clean extraction** of only the 2 unique changes.

## Testing
- ✅ `flutter gen-l10n`: Success
- ✅ Changes isolated and minimal
- ✅ No conflicts with master

## Related
- Supersedes #2 (will be closed)
- Builds on top of #1 (merged)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)